### PR TITLE
Updated pchMessageStart values to match Defcoin network's values

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -111,10 +111,10 @@ public:
          * The characters are rarely used upper ASCII, not valid as UTF-8, and produce
          * a large 32-bit integer with any alignment.
          */
-        pchMessageStart[0] = 0xfb;
-        pchMessageStart[1] = 0xc0;
-        pchMessageStart[2] = 0xb6;
-        pchMessageStart[3] = 0xdb;
+        pchMessageStart[0] = 0xfc;
+        pchMessageStart[1] = 0xc1;
+        pchMessageStart[2] = 0xb7;
+        pchMessageStart[3] = 0xdc;
         nDefaultPort = 1337;
         nPruneAfterHeight = 100000;
 


### PR DESCRIPTION
This fix resolves a variety of issues on the Defcoin network including:

1. Litecoin nodes are accidentally receiving Defcoin transactions (but they're not confirming since the UTXOs are different)
2. Light DFC clients (like Beerwallet and the Android wallet) aren't properly communicating with nodes
3. Differing versions of DFC nodes cannot communicate with each other

Huge props to `charlesrocket` for finding this issue so I am able to submit a fix