### PR TITLE
Fix seed domains to resolve correctly

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -124,10 +124,9 @@ public:
         assert(genesis.hashMerkleRoot == uint256S("0x7294da28c1b8eeba868388b14e2205874fb512f0ca31c2f583002557175f2c9c"));
 
         // Note that of those with the service bits flag, most only support a subset of possible options
-        vSeeds.emplace_back("seed.defcoin-ng.org", true);
-        vSeeds.emplace_back("seed2.defcoin-ng.org", true);
-        vSeeds.emplace_back("seed3.defcoin-ng.org", true);
-        vSeeds.emplace_back("seed.defcoin.mikej.tech", true);
+        vSeeds.emplace_back("seed.defcoin-ng.org", false);
+        vSeeds.emplace_back("seed2.defcoin-ng.org", false);
+        vSeeds.emplace_back("seed.defcoin.mikej.tech", false);
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,30);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,5);
@@ -227,10 +226,7 @@ public:
         vFixedSeeds.clear();
         vSeeds.clear();
         // nodes with support for servicebits filtering should be at the top
-        vSeeds.emplace_back("test.defcoin-ng.org", true);
-        vSeeds.emplace_back("test2.defcoin-ng.org", true);
-        vSeeds.emplace_back("test3.defcoin-ng.org", true);
-        vSeeds.emplace_back("test4.defcoin-ng.org", true);
+        vSeeds.emplace_back("test.defcoin-ng.org", false);
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);


### PR DESCRIPTION
This changes each domain to resolve the string provided instead of prepending `x9.` to the begging of the domain name.